### PR TITLE
Autogenerate openapi.json

### DIFF
--- a/.github/workflows/generate_api_ref.yaml
+++ b/.github/workflows/generate_api_ref.yaml
@@ -1,0 +1,36 @@
+name: "Generate openapi.json"
+
+env:
+  DEFAULT_PYTHON_VERSION: "3.10"
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  update-openapi-json:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          environment-file: conda-store-server/environment-dev.yaml
+
+      - name: Install conda-store-server
+        run: python -m pip install conda-store-server/.
+
+      - name: Run openapi.json generation script
+        run: python docusaurus-docs/scripts/generate_openapi_json.py
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "[AUTO] Update openapi.json"
+          title: "[AUTO] Update openapi.json"

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ conda-store-server/conda_store_server/server/static/conda-store-ui/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# conda-store-server
+conda-store.sqlite

--- a/docusaurus-docs/scripts/generate_openapi_json.py
+++ b/docusaurus-docs/scripts/generate_openapi_json.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+from conda_store_server.server import app as server_app
+from fastapi.openapi.utils import get_openapi
+
+
+def gen_openapi_json():
+    cs_server = server_app.CondaStoreServer()
+    cs_server.initialize()
+    app = cs_server.init_fastapi_app()
+    filepath = Path(__file__).parent / "../static/openapi.json"
+
+    with open(filepath, "w") as f:
+        json.dump(
+            get_openapi(
+                title=app.title,
+                version=app.version,
+                openapi_version=app.openapi_version,
+                description=app.description,
+                routes=app.routes,
+            ),
+            f,
+        )
+
+
+def main():
+    gen_openapi_json()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Addresses #

<!-- Reference the issue corresponding to this PR. If an issues does not exist, consider opening one or writing a detailed description for what this PR changes and it's value in the following sections. -->
<!-- GitHub Docs on Keywords: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Description

<!-- What is the purpose of this pull request? -->

This pull request:

- Adds a script and an action to autogenerate `openapi.json` on each conda-store release. The `openapi.json` files is used to generate the REST API reference documentation.

## Pull request checklist

<!-- Quick checklist to ensure high-quality Pull Request. -->

- [ ] Did you test this change locally?
- [ ] Did you update the documentation (if required)?
- [ ] Did you add/update relevant tests for this change (if required)?

## Additional information

<!-- Do you have any other information about this pull request? This may include screenshots, references, and/or implementation notes. -->

While this _works_, there is likely a cleaner/minimal way to do this. Please let me know if you ideas to simplify this!

## How to test

<!-- Steps to take to test the new feature, verify the bug is fixed, etc. Please do not just include steps for the happy path, but failure modes too. -->

I've tested it on my fork: https://github.com/pavithraes/conda-store/pull/2

We can temporarily enable the action on pushes to this branch for testing:

```yml
on:
  push:
    branches:
      - "<>"
```
